### PR TITLE
Gon print character

### DIFF
--- a/ucum-source.xml
+++ b/ucum-source.xml
@@ -1540,7 +1540,7 @@ out of scope of &TUCUM;.
 
     <u:units id="iso1000">
       <caption>Other units from ISO&nbsp;1000, ISO&nbsp;2955, and some from ANSI&nbsp;X3.50.</caption>
-<u:unit id="200040" Code="gon" CODE="GON" isMetric="no"><name>gon</name><name>grade</name><printSymbol>&box;<sup>g</sup></printSymbol><property>plane angle</property><value Unit="deg" UNIT="DEG" value="0.9">0.9</value></u:unit>
+<u:unit id="200040" Code="gon" CODE="GON" isMetric="no"><name>gon</name><name>grade</name><printSymbol><sup>g</sup></printSymbol><property>plane angle</property><value Unit="deg" UNIT="DEG" value="0.9">0.9</value></u:unit>
 <u:unit id="200010" Code="deg" CODE="DEG" isMetric="no"><name>degree</name><printSymbol>&deg;</printSymbol><property>plane angle</property><value Unit="[pi].rad/360" UNIT="[PI].RAD/360" value="2">2</value></u:unit>
 <u:unit id="200020" Code="'" CODE="'" isMetric="no"><name>minute</name><printSymbol>'</printSymbol><property>plane angle</property><value Unit="deg/60" UNIT="DEG/60" value="1">1</value></u:unit>
 <u:unit id="200030" Code="''" CODE="''" isMetric="no"><name>second</name><printSymbol>''</printSymbol><property>plane angle</property><value Unit="'/60" UNIT="'/60" value="1">1</value></u:unit>

--- a/ucum.html
+++ b/ucum.html
@@ -1546,7 +1546,7 @@
         <tr>
             <td>gon, grade&nbsp;</td>
             <td>plane angle&nbsp;</td>
-            <td>□<sup>g</sup>&nbsp;
+            <td><sup>g</sup>&nbsp;
             </td>
             <td><code>gon</code>&nbsp;
             </td>

--- a/ucum.xml
+++ b/ucum.xml
@@ -3749,7 +3749,7 @@
                     .2.
                      
                     <emph role="strong">
-                        <emph role="sup"> ■3</emph>
+                        <emph role="sup">3</emph>
                     </emph>
 
                     Only the columns titled “c/s,” “c/i,”
@@ -3775,7 +3775,6 @@
                         <td>gon, grade </td>
                         <td>plane angle </td>
                         <td>
-                            □
                             <emph role="sup">g</emph>
                         </td>
                         <td>


### PR DESCRIPTION
Remove box character &box; in front of <sup>g</sup> for gradiant/Gon unit, as discussed in UCUM board meeting on 2023-04-25.